### PR TITLE
chore(cargo): update `homepage` to `repository`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "righor"
 version = "0.2.1"
 edition = "2021"
 license = "MIT"
-homepage = "https://github.com/Thopic/righor"
+repository = "https://github.com/Thopic/righor"
 description = "Righor creates model of Ig/TCR sequences from sequencing data."
 
 


### PR DESCRIPTION
Change `homepage` key to instead use the [repository](https://rust-digger.code-maven.com/about-repository) key for correctly labeling/pointing to the GitHub repo.

This makes location of the source code easier to see Crates.io. 🙂