### PR TITLE
Added parallelized generation

### DIFF
--- a/src/shared/utils.rs
+++ b/src/shared/utils.rs
@@ -394,3 +394,11 @@ pub fn difference_as_i64(a: usize, b: usize) -> i64 {
         -((b - a) as i64)
     }
 }
+
+pub fn get_batches(n: usize, num_batches: usize) -> Vec<usize> {
+    let remainder: usize = n % num_batches;
+    let quotient: usize = n / num_batches;
+    let mut batches = vec![quotient; num_batches - remainder];
+    batches.extend_from_slice(&vec![quotient + 1; remainder]);
+    batches
+}


### PR DESCRIPTION
Generation of sequences is now parallelized on the Rust backend.

I use the number of threads as the number of batches and compute the batch sizes from the requested number of Monte Carlo sequences. Child random number generators are created using the Generator's random number generator. Each thread (batch) gets its own random number generator.

I'm not sure how best to treat the unwrapping of `GenerationResult.junction_aa` sequences. Since I expect to return a vector of strings, I unwrap None values as `Out-of-frame`. Additionally, I'm not sure how economical it is to clone the model attribute, but I imagine it's not that large.