### PR TITLE
Added function for computing productive norm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -738,6 +738,21 @@ impl PyModel {
             .into_pyarray_bound(py)
             .into())
     }
+
+    #[pyo3(signature = (num_monte_carlo=1_000_000, conserved_j_residues="ACDEFGHIKLMNPQRSTVWY", seed=None))]
+    pub fn get_norm_productive(
+        &self,
+        num_monte_carlo: Option<usize>,
+        conserved_j_residues: Option<&str>,
+        seed: Option<u64>,
+    ) -> Result<f64> {
+        Ok(Model::get_norm_productive(
+            &self.inner,
+            num_monte_carlo,
+            conserved_j_residues,
+            seed,
+        ))
+    }
 }
 
 #[cfg(all(feature = "py_binds", feature = "pyo3"))]

--- a/src/shared/model.rs
+++ b/src/shared/model.rs
@@ -818,6 +818,17 @@ impl Generator {
             .generate_without_errors(functional, &mut self.rng)
     }
 
+    pub fn generate_without_and_with_errors(
+        &mut self,
+        functional: bool,
+    ) -> (GenerationResult, GenerationResult) {
+        let (res_without_err, res_with_error) = self
+            .model
+            .generate_without_and_with_errors(functional, &mut self.rng);
+        //let res_with_error = Some(res_with_error);
+        (res_without_err, res_with_error.unwrap())
+    }
+
     pub fn generate_many(&mut self, num_monte_carlo: usize, functional: bool) -> Vec<[String; 5]> {
         let num_threads = current_num_threads();
         let batches: Vec<usize> = get_batches(num_monte_carlo, num_threads);
@@ -827,10 +838,11 @@ impl Generator {
             .into_par_iter()
             .enumerate()
             .flat_map_iter(|(idx, s)| {
-                let mut child_rng = SmallRng::seed_from_u64(s);
-                let mut child_model = self.model.clone();
+                let mut child_generator =
+                    Generator::new(&self.model, Some(s), None::<Vec<Gene>>, None::<Vec<Gene>>)
+                        .unwrap();
                 (0..batches[idx]).into_iter().map(move |_| {
-                    let gen_result = child_model.generate(functional, &mut child_rng).unwrap();
+                    let gen_result = child_generator.generate(functional).unwrap();
                     [
                         gen_result.junction_aa.unwrap_or("Out-of-frame".to_string()),
                         gen_result.v_gene,
@@ -856,11 +868,11 @@ impl Generator {
             .into_par_iter()
             .enumerate()
             .flat_map_iter(|(idx, s)| {
-                let mut child_rng = SmallRng::seed_from_u64(s);
-                let mut child_model = self.model.clone();
+                let mut child_generator =
+                    Generator::new(&self.model, Some(s), None::<Vec<Gene>>, None::<Vec<Gene>>)
+                        .unwrap();
                 (0..batches[idx]).into_iter().map(move |_| {
-                    let gen_result =
-                        child_model.generate_without_errors(functional, &mut child_rng);
+                    let gen_result = child_generator.generate_without_errors(functional);
                     [
                         gen_result.junction_aa.unwrap_or("Out-of-frame".to_string()),
                         gen_result.v_gene,
@@ -870,6 +882,42 @@ impl Generator {
                 })
             })
             .collect::<Vec<[String; 4]>>()
+    }
+
+    pub fn generate_many_without_and_with_errors(
+        &mut self,
+        num_monte_carlo: usize,
+        functional: bool,
+    ) -> Vec<[String; 6]> {
+        let num_threads = current_num_threads();
+        let batches: Vec<usize> = get_batches(num_monte_carlo, num_threads);
+        let seeds: Vec<u64> = (0..num_threads).map(|_| self.rng.next_u64()).collect();
+
+        seeds
+            .into_par_iter()
+            .enumerate()
+            .flat_map_iter(|(idx, s)| {
+                let mut child_generator =
+                    Generator::new(&self.model, Some(s), None::<Vec<Gene>>, None::<Vec<Gene>>)
+                        .unwrap();
+                (0..batches[idx]).into_iter().map(move |_| {
+                    let (res_without_error, res_with_error) =
+                        child_generator.generate_without_and_with_errors(functional);
+                    [
+                        res_without_error
+                            .junction_aa
+                            .unwrap_or("Out-of-frame".to_string()),
+                        res_without_error.v_gene,
+                        res_without_error.j_gene,
+                        res_without_error.junction_nt,
+                        res_with_error
+                            .junction_aa
+                            .unwrap_or("Out-of-frame".to_string()),
+                        res_with_error.junction_nt,
+                    ]
+                })
+            })
+            .collect::<Vec<[String; 6]>>()
     }
 }
 
@@ -931,6 +979,13 @@ pub trait Modelable {
 
     /// Generate a sequence
     fn generate<R: Rng>(&mut self, functional: bool, rng: &mut R) -> Result<GenerationResult>;
+
+    /// Generate a sequence without and with errors
+    fn generate_without_and_with_errors<R: Rng>(
+        &mut self,
+        functional: bool,
+        rng: &mut R,
+    ) -> (GenerationResult, Result<GenerationResult>);
 
     /// Generate a sequence without taking into account the error rate
     fn generate_without_errors<R: Rng>(
@@ -1021,6 +1076,17 @@ impl Model {
         match self {
             Model::VDJ(x) => x.generate(functional, rng),
             Model::VJ(x) => x.generate(functional, rng),
+        }
+    }
+
+    pub fn generate_without_and_with_errors<R: Rng>(
+        &mut self,
+        functional: bool,
+        rng: &mut R,
+    ) -> (GenerationResult, Result<GenerationResult>) {
+        match self {
+            Model::VDJ(x) => x.generate_without_and_with_errors(functional, rng),
+            Model::VJ(x) => x.generate_without_and_with_errors(functional, rng),
         }
     }
 }

--- a/src/vj/model.rs
+++ b/src/vj/model.rs
@@ -233,6 +233,14 @@ impl Modelable for Model {
         })
     }
 
+    fn generate_without_and_with_errors<R: Rng>(
+        &mut self,
+        functional: bool,
+        rng: &mut R,
+    ) -> (GenerationResult, Result<GenerationResult>) {
+        self.inner.generate_without_and_with_errors(functional, rng)
+    }
+
     fn generate_without_errors<R: Rng>(
         &mut self,
         functional: bool,


### PR DESCRIPTION
Considering all the conditions that need to be met for a sequence to be productive and since we care only about whether a sequence is productive, I implemented a `get_productive_norm` function for righor. I tested it against some different igor models I had using an adapted method of OLGA's to compute the fraction of productive sequences with Monte Carlo and using OLGA's pgen function. Things seemed within reason in my tests.

I added the `conserved_j_residues` parameter since OLGA doesn't care about the last residue when computing the productive norm. On the other hand, [OLGA restricts the last residue to be `FWV`](https://github.com/statbiophys/OLGA/blob/4e0bc36ec40acc2ad93b2878e348512e71955a01/olga/sequence_generation.py#L188) by default, but [sonnia relaxes this constraint to any amino acid residue](https://github.com/statbiophys/soNNia/blob/4d6e4f6f70f6f3715fa3af97c7803395269237b9/sonnia/utils.py#L704). When I have time, I'll add this parameter to righor for generating sequences, but there the default will be `FWV`. As is, righor requires the last residue be `F` or `W`.

Please have a look see if I'm missing anything.